### PR TITLE
Add I2C slave helpers

### DIFF
--- a/examples/example_08-I2C_master_send.c
+++ b/examples/example_08-I2C_master_send.c
@@ -1,0 +1,29 @@
+/**
+ * @file     example_08-I2C_master_send.c
+ * @brief    Demonstrates sending a short text over I2C in master mode.
+ *           Configure the address and port using the macros below.
+ */
+
+/* Configuration overrides */
+#define I2C2_ENABLE       1
+#define I2C2_MASTER       1
+#define I2C2_PINPACK      0
+#define I2C2_SPEED        100000U
+
+#include "stm32_kit.h"
+#include "stm32_kit/i2c.h"
+
+BOARD_SETUP void setup(void) {
+  SystemCoreClockUpdate();
+  SysTick_Config(SystemCoreClock / 10000);
+  I2C_setup(I2C2);                         /* use I2C2 master */
+}
+
+int main(void) {
+  static const char msg[] = "Hello slave";
+  while (1) {
+    I2C_write(I2C2, 0x42, msg, sizeof(msg) - 1);
+    delay_ms(1000);
+  }
+}
+

--- a/examples/example_09-I2C_slave_display.c
+++ b/examples/example_09-I2C_slave_display.c
@@ -1,0 +1,34 @@
+/**
+ * @file     example_09-I2C_slave_display.c
+ * @brief    Receives a message over I2C and shows it on the LCD.
+ *           Intended to run on a second board configured as I2C slave.
+ */
+
+/* Configuration overrides */
+#define I2C2_ENABLE       1
+#define I2C2_MASTER       0
+#define I2C2_PINPACK      0
+#define I2C2_OWN_ADDRESS  0x42
+
+#include "stm32_kit.h"
+#include "stm32_kit/i2c.h"
+#include "stm32_kit/lcd.h"
+
+BOARD_SETUP void setup(void) {
+  SystemCoreClockUpdate();
+  SysTick_Config(SystemCoreClock / 10000);
+  LCD_setup();
+  I2C_setup(I2C2);                         /* use I2C2 slave */
+}
+
+int main(void) {
+  uint8_t text[32];
+  while (1) {
+    int n = I2C_slave_read(I2C2, text, sizeof(text)-1);
+    text[n] = '\0';
+    LCD_set(LCD_CLR);
+    LCD_set(LCD_LINE1);
+    LCD_print((char*)text);
+  }
+}
+

--- a/stm32/boards/disc/f407.h
+++ b/stm32/boards/disc/f407.h
@@ -83,6 +83,31 @@
 #   define KEYPAD_R2    (PD8)
 #   define KEYPAD_R3    (PD9)
 
+/* I2C setup
+ * Pin packs available on DISC F407 board
+ */
+#   define I2C1_SCL_PP0     (PB6)
+#   define I2C1_SDA_PP0     (PB7)
+#   define I2C1_SCL_PP1     (PB8)
+#   define I2C1_SDA_PP1     (PB9)
+#   define I2C2_SCL_PP0     (PB10)
+#   define I2C2_SDA_PP0     (PB11)
+#   define I2C2_SCL_PP1     (PF1)
+#   define I2C2_SDA_PP1     (PF0)
+#   define I2C2_SCL_PP2     (PH4)
+#   define I2C2_SDA_PP2     (PH5)
+#   define I2C3_SCL_PP0     (PA8)
+#   define I2C3_SDA_PP0     (PC9)
+#   define I2C3_SCL_PP1     (PH7)
+#   define I2C3_SDA_PP1     (PH8)
+
+#   define I2C1_SCL     I2C1_SCL_PP0
+#   define I2C1_SDA     I2C1_SDA_PP0
+#   define I2C2_SCL     I2C2_SCL_PP0
+#   define I2C2_SDA     I2C2_SDA_PP0
+#   define I2C3_SCL     I2C3_SCL_PP0
+#   define I2C3_SDA     I2C3_SDA_PP0
+
 /* ADC setup */
 #   define ADC_1        (PA1)
 

--- a/stm32/boards/nucleo/f401.h
+++ b/stm32/boards/nucleo/f401.h
@@ -91,6 +91,10 @@
 #   define KEYPAD_R2   (PB4)
 #   define KEYPAD_R3   (PB5)
 
+/* I2C setup */
+#   define I2C1_SCL    (PB8)
+#   define I2C1_SDA    (PB9)
+
 /* ADC setup */
 #   define ADC_1       (PA1)
 

--- a/stm32/boards/nucleo/g071.h
+++ b/stm32/boards/nucleo/g071.h
@@ -85,6 +85,10 @@
 #   define KEYPAD_R2   (PC11)
 #   define KEYPAD_R3   (PC12)
 
+/* I2C setup */
+#   define I2C1_SCL    (PB8)
+#   define I2C1_SDA    (PB9)
+
 /* ADC setup */
 #   define ADC_1       (PA1)
 

--- a/stm32/boards/nucleo/l151.h
+++ b/stm32/boards/nucleo/l151.h
@@ -43,6 +43,10 @@
 #   define KEYPAD_R2  (NC)
 #   define KEYPAD_R3  (NC)
 
+/* I2C setup */
+#   define I2C1_SCL   (NC)
+#   define I2C1_SDA   (NC)
+
 /* ADC setup */
 #   define ADC_1      (PA1)
 

--- a/stm32/config/config.h
+++ b/stm32/config/config.h
@@ -50,6 +50,242 @@ extern "C" {
  #define LCD_ROWS      2
 #endif
 
+// <q>Use I2C LCD backend
+// <i> Enable support for LCD modules connected via I2C expander
+#ifndef LCD_USE_I2C
+ #define LCD_USE_I2C   0
+#endif
+
+// <o>LCD I2C address <0-255>
+// <i> 7bit address of the I2C LCD expander
+#ifndef LCD_I2C_ADDR
+ #define LCD_I2C_ADDR  0x27
+#endif
+
+// <o>LCD I2C port <1-3>
+// <i> Choose the I2C peripheral used for the LCD backend
+#ifndef LCD_I2C_PORT
+ #define LCD_I2C_PORT  1
+#endif
+
+// </h>
+
+// <h> I2C
+// ===============================
+// <o>Default I2C bus speed <1000-400000>
+// <i> Target I2C bus frequency in Hz
+// <i> Default: 100000
+#ifndef I2C_SPEED
+ #define I2C_SPEED 100000U
+#endif
+
+// <e>I2C1
+// <q>Enable I2C1
+// <i> Include support for I2C1 peripheral
+// <i> Default: 1
+#ifndef I2C1_ENABLE
+ #define I2C1_ENABLE 1
+#endif
+// <o>Pin pack <0-2>
+// <i> Select pin pack used for I2C1 pins
+// <i> Default: 0
+#ifndef I2C1_PINPACK
+ #define I2C1_PINPACK 0
+#endif
+// <o>Speed <1000-400000>
+// <i> Bus speed in Hz
+// <i> Default: I2C_SPEED
+#ifndef I2C1_SPEED
+ #define I2C1_SPEED I2C_SPEED
+#endif
+// <q>Master mode
+// <i> Set to 1 for master mode operation
+// <i> Default: 1
+#ifndef I2C1_MASTER
+ #define I2C1_MASTER 1
+#endif
+// <q>10-bit addressing
+// <i> Enable 10-bit addressing mode
+// <i> Default: 0
+#ifndef I2C1_ADDR10
+ #define I2C1_ADDR10 0
+#endif
+// <q>Dual address mode
+// <i> Respond to second own address
+// <i> Default: 0
+#ifndef I2C1_DUAL
+ #define I2C1_DUAL 0
+#endif
+// <o>Second address <0-1023>
+// <i> Secondary address used when dual mode enabled
+// <i> Default: 0
+#ifndef I2C1_SECOND_ADDRESS
+ #define I2C1_SECOND_ADDRESS 0
+#endif
+// <q>General Call enable
+// <i> Respond to general call 0x00
+// <i> Default: 0
+#ifndef I2C1_GEN_CALL
+ #define I2C1_GEN_CALL 0
+#endif
+// <q>No stretch
+// <i> Disable clock stretching
+// <i> Default: 0
+#ifndef I2C1_NOSTRETCH
+ #define I2C1_NOSTRETCH 0
+#endif
+// <q>Fast duty cycle 16/9
+// <i> Use 16/9 duty cycle in Fast mode
+// <i> Default: 0
+#ifndef I2C1_DUTY
+ #define I2C1_DUTY 0
+#endif
+// <o>Own address <0-1023>
+// <i> Primary own address of I2C1
+// <i> Default: 0x00
+#ifndef I2C1_OWN_ADDRESS
+ #define I2C1_OWN_ADDRESS 0x00
+#endif
+// </e>
+
+// <e>I2C2
+// <q>Enable I2C2
+// <i> Include support for I2C2 peripheral
+// <i> Default: 1
+#ifndef I2C2_ENABLE
+ #define I2C2_ENABLE 1
+#endif
+// <o>Pin pack <0-2>
+// <i> Select pin pack used for I2C2 pins
+// <i> Default: 0
+#ifndef I2C2_PINPACK
+ #define I2C2_PINPACK 0
+#endif
+// <o>Speed <1000-400000>
+// <i> Bus speed in Hz
+// <i> Default: I2C_SPEED
+#ifndef I2C2_SPEED
+ #define I2C2_SPEED I2C_SPEED
+#endif
+// <q>Master mode
+// <i> Set to 1 for master mode operation
+// <i> Default: 1
+#ifndef I2C2_MASTER
+ #define I2C2_MASTER 1
+#endif
+// <q>10-bit addressing
+// <i> Enable 10-bit addressing mode
+// <i> Default: 0
+#ifndef I2C2_ADDR10
+ #define I2C2_ADDR10 0
+#endif
+// <q>Dual address mode
+// <i> Respond to second own address
+// <i> Default: 0
+#ifndef I2C2_DUAL
+ #define I2C2_DUAL 0
+#endif
+// <o>Second address <0-1023>
+// <i> Secondary address used when dual mode enabled
+// <i> Default: 0
+#ifndef I2C2_SECOND_ADDRESS
+ #define I2C2_SECOND_ADDRESS 0
+#endif
+// <q>General Call enable
+// <i> Respond to general call 0x00
+// <i> Default: 0
+#ifndef I2C2_GEN_CALL
+ #define I2C2_GEN_CALL 0
+#endif
+// <q>No stretch
+// <i> Disable clock stretching
+// <i> Default: 0
+#ifndef I2C2_NOSTRETCH
+ #define I2C2_NOSTRETCH 0
+#endif
+// <q>Fast duty cycle 16/9
+// <i> Use 16/9 duty cycle in Fast mode
+// <i> Default: 0
+#ifndef I2C2_DUTY
+ #define I2C2_DUTY 0
+#endif
+// <o>Own address <0-1023>
+// <i> Primary own address of I2C2
+// <i> Default: 0x00
+#ifndef I2C2_OWN_ADDRESS
+ #define I2C2_OWN_ADDRESS 0x00
+#endif
+// </e>
+
+// <e>I2C3
+// <q>Enable I2C3
+// <i> Include support for I2C3 peripheral
+// <i> Default: 1
+#ifndef I2C3_ENABLE
+ #define I2C3_ENABLE 1
+#endif
+// <o>Pin pack <0-2>
+// <i> Select pin pack used for I2C3 pins
+// <i> Default: 0
+#ifndef I2C3_PINPACK
+ #define I2C3_PINPACK 0
+#endif
+// <o>Speed <1000-400000>
+// <i> Bus speed in Hz
+// <i> Default: I2C_SPEED
+#ifndef I2C3_SPEED
+ #define I2C3_SPEED I2C_SPEED
+#endif
+// <q>Master mode
+// <i> Set to 1 for master mode operation
+// <i> Default: 1
+#ifndef I2C3_MASTER
+ #define I2C3_MASTER 1
+#endif
+// <q>10-bit addressing
+// <i> Enable 10-bit addressing mode
+// <i> Default: 0
+#ifndef I2C3_ADDR10
+ #define I2C3_ADDR10 0
+#endif
+// <q>Dual address mode
+// <i> Respond to second own address
+// <i> Default: 0
+#ifndef I2C3_DUAL
+ #define I2C3_DUAL 0
+#endif
+// <o>Second address <0-1023>
+// <i> Secondary address used when dual mode enabled
+// <i> Default: 0
+#ifndef I2C3_SECOND_ADDRESS
+ #define I2C3_SECOND_ADDRESS 0
+#endif
+// <q>General Call enable
+// <i> Respond to general call 0x00
+// <i> Default: 0
+#ifndef I2C3_GEN_CALL
+ #define I2C3_GEN_CALL 0
+#endif
+// <q>No stretch
+// <i> Disable clock stretching
+// <i> Default: 0
+#ifndef I2C3_NOSTRETCH
+ #define I2C3_NOSTRETCH 0
+#endif
+// <q>Fast duty cycle 16/9
+// <i> Use 16/9 duty cycle in Fast mode
+// <i> Default: 0
+#ifndef I2C3_DUTY
+ #define I2C3_DUTY 0
+#endif
+// <o>Own address <0-1023>
+// <i> Primary own address of I2C3
+// <i> Default: 0x00
+#ifndef I2C3_OWN_ADDRESS
+ #define I2C3_OWN_ADDRESS 0x00
+#endif
+// </e>
+
 
 // </h>
 

--- a/stm32/include/stm32_kit/i2c.h
+++ b/stm32/include/stm32_kit/i2c.h
@@ -1,0 +1,316 @@
+/**
+ * @file       i2c.h
+ * @brief      Minimal I2C driver using only CMSIS
+ */
+#ifndef STM32_KIT_I2C
+#define STM32_KIT_I2C
+
+#include "platform.h"
+#include "gpio.h"
+#include "pin.h"
+#include "boards.h"
+
+typedef struct {
+    uint32_t speed;
+    uint16_t own_address;
+    uint16_t own_address2;
+    uint8_t master;
+    uint8_t addr10;
+    uint8_t dual;
+    uint8_t general_call;
+    uint8_t duty;
+    uint8_t nostretch;
+    uint8_t pinpack;
+} I2C_Config;
+
+static inline void I2C_load_config(I2C_TypeDef *i2c, I2C_Config *cfg) {
+    cfg->speed = I2C_SPEED;
+    cfg->own_address = 0;
+    cfg->own_address2 = 0;
+    cfg->master = 1;
+    cfg->addr10 = 0;
+    cfg->dual = 0;
+    cfg->general_call = 0;
+    cfg->duty = 0;
+    cfg->nostretch = 0;
+    cfg->pinpack = 0;
+
+#define I2C_OPT(bus, name) I2C##bus##_##name
+#define I2C_LOAD(bus)                            \
+    do {                                        \
+        cfg->speed       = I2C_OPT(bus, SPEED);  \
+        cfg->master      = I2C_OPT(bus, MASTER); \
+        cfg->addr10      = I2C_OPT(bus, ADDR10); \
+        cfg->dual        = I2C_OPT(bus, DUAL);   \
+        cfg->general_call= I2C_OPT(bus, GEN_CALL);\
+        cfg->duty        = I2C_OPT(bus, DUTY);   \
+        cfg->nostretch   = I2C_OPT(bus, NOSTRETCH);\
+        cfg->own_address = I2C_OPT(bus, OWN_ADDRESS);\
+        cfg->own_address2= I2C_OPT(bus, SECOND_ADDRESS);\
+        cfg->pinpack     = I2C_OPT(bus, PINPACK);\
+    } while (0)
+
+    if (i2c == I2C1) {
+        I2C_LOAD(1);
+    } else if (i2c == I2C2) {
+        I2C_LOAD(2);
+    } else if (i2c == I2C3) {
+        I2C_LOAD(3);
+    }
+
+#undef I2C_LOAD
+#undef I2C_OPT
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Default speed for I2C bus */
+#ifndef I2C_SPEED
+# define I2C_SPEED 100000U
+#endif
+
+/** Wait for selected flag in SR1 register */
+static inline void I2C_wait_flag(I2C_TypeDef *i2c, uint32_t flag) {
+    while (!(i2c->SR1 & flag)) {
+        /* busy wait */
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+/* Peripheral selection based on pins                                         */
+/*----------------------------------------------------------------------------*/
+static inline I2C_TypeDef *I2C_autoselect(enum pin scl, enum pin sda) {
+#if (STM32_TYPE == 407)
+    if ((scl == PB6 && sda == PB7) || (scl == PB8 && sda == PB9))
+        return I2C1;
+    if ((scl == PB10 && sda == PB11) || (scl == PF1 && sda == PF0) ||
+        (scl == PH4 && sda == PH5))
+        return I2C2;
+    if ((scl == PA8 && sda == PC9) || (scl == PH7 && sda == PH8))
+        return I2C3;
+    return 0;
+#elif (STM32_TYPE == 401)
+    if ((scl == PB6 && sda == PB7) || (scl == PB8 && sda == PB9))
+        return I2C1;
+    return 0;
+#elif (STM32_TYPE == 71)
+    if (scl == PB8 && sda == PB9)
+        return I2C1;
+    return 0;
+#else
+# error "I2C_autoselect not implemented for this MCU"
+#endif
+}
+
+static inline void I2C_pinpack_pins(I2C_TypeDef *i2c, uint8_t pack, enum pin *scl, enum pin *sda) {
+#if (STM32_TYPE == 407)
+    if (i2c == I2C1) {
+        *scl = (pack ? I2C1_SCL_PP1 : I2C1_SCL_PP0);
+        *sda = (pack ? I2C1_SDA_PP1 : I2C1_SDA_PP0);
+    } else if (i2c == I2C2) {
+        switch (pack) {
+        case 1: *scl = I2C2_SCL_PP1; *sda = I2C2_SDA_PP1; break;
+        case 2: *scl = I2C2_SCL_PP2; *sda = I2C2_SDA_PP2; break;
+        default: *scl = I2C2_SCL_PP0; *sda = I2C2_SDA_PP0; break;
+        }
+    } else if (i2c == I2C3) {
+        *scl = (pack ? I2C3_SCL_PP1 : I2C3_SCL_PP0);
+        *sda = (pack ? I2C3_SDA_PP1 : I2C3_SDA_PP0);
+    } else {
+        *scl = NC; *sda = NC;
+    }
+#else
+#error "I2C pin packs not defined for this MCU"
+#endif
+}
+
+/*----------------------------------------------------------------------------*/
+/* Clock configuration                                                         */
+/*----------------------------------------------------------------------------*/
+static inline void I2C_clock(I2C_TypeDef *i2c, uint32_t pclk, const I2C_Config *c) {
+    uint32_t freq = pclk / 1000000U;
+    uint32_t speed = c->speed;
+    i2c->CR2 = freq;
+    if (speed > 100000U) {
+        uint32_t ccr;
+        if (c->duty) {
+            ccr = pclk / (speed * 25U);
+            i2c->CCR = ccr | I2C_CCR_FS | I2C_CCR_DUTY;
+        } else {
+            ccr = pclk / (speed * 3U);
+            i2c->CCR = ccr | I2C_CCR_FS;
+        }
+        i2c->TRISE = (freq * 300U) / 1000U + 1U;
+    } else {
+        uint32_t ccr = pclk / (speed << 1);
+        if (ccr < 4U) ccr = 4U;
+        i2c->CCR = ccr;
+        i2c->TRISE = freq + 1U;
+    }
+}
+
+/*----------------------------------------------------------------------------*/
+/* Basic setup                                                                 */
+/*----------------------------------------------------------------------------*/
+static inline I2C_TypeDef *I2C_setup(I2C_TypeDef *i2c) {
+    enum pin scl, sda;
+    I2C_Config c;
+    I2C_load_config(i2c, &c);
+#if (STM32_TYPE == 407)
+    if (i2c == I2C1 && !I2C1_ENABLE) return 0;
+    if (i2c == I2C2 && !I2C2_ENABLE) return 0;
+    if (i2c == I2C3 && !I2C3_ENABLE) return 0;
+#elif (STM32_TYPE == 401)
+    if (i2c == I2C1 && !I2C1_ENABLE) return 0;
+#elif (STM32_TYPE == 71)
+    if (i2c == I2C1 && !I2C1_ENABLE) return 0;
+#endif
+    I2C_pinpack_pins(i2c, c.pinpack, &scl, &sda);
+    if (scl == NC || sda == NC)
+        return 0;
+
+    pin_setup_af(scl, PIN_MODE_AF, PIN_PULL_UP, PIN_SPEED_HIGH, PIN_TYPE_OPENDRAIN, PIN_AF4);
+    pin_setup_af(sda, PIN_MODE_AF, PIN_PULL_UP, PIN_SPEED_HIGH, PIN_TYPE_OPENDRAIN, PIN_AF4);
+
+#if (STM32_TYPE == 407)
+    if (i2c == I2C1) RCC->APB1ENR |= RCC_APB1ENR_I2C1EN;
+    if (i2c == I2C2) RCC->APB1ENR |= RCC_APB1ENR_I2C2EN;
+    if (i2c == I2C3) RCC->APB1ENR |= RCC_APB1ENR_I2C3EN;
+#elif (STM32_TYPE == 401) || (STM32_TYPE == 411)
+    if (i2c == I2C1) RCC->APB1ENR |= RCC_APB1ENR_I2C1EN;
+#elif (STM32_TYPE == 71)
+    if (i2c == I2C1) RCC->APB1ENR |= RCC_APB1ENR_I2C1EN;
+#endif
+
+    i2c->CR1 = c.nostretch ? I2C_CR1_NOSTRETCH : 0;
+    if (c.general_call)
+        i2c->CR1 |= I2C_CR1_ENGC;
+    I2C_clock(i2c, SystemCoreClock, &c);
+    if (!c.master) {
+        i2c->OAR1 = (c.addr10 ? I2C_OAR1_ADDMODE : 0) |
+                    (c.own_address & (c.addr10 ? 0x03FF : 0x7F));
+        if (c.dual)
+            i2c->OAR2 = I2C_OAR2_ENDUAL | (c.own_address2 & 0x7F);
+    }
+    i2c->CR1 |= I2C_CR1_PE;
+    return i2c;
+}
+
+/*----------------------------------------------------------------------------*/
+/* Utility commands                                                            */
+/*----------------------------------------------------------------------------*/
+static inline void I2C_start(I2C_TypeDef *i2c) {
+    i2c->CR1 |= I2C_CR1_START;
+    I2C_wait_flag(i2c, I2C_SR1_SB);
+}
+
+static inline void I2C_stop(I2C_TypeDef *i2c) {
+    i2c->CR1 |= I2C_CR1_STOP;
+}
+
+static inline void I2C_opt_send_addr(I2C_TypeDef *i2c, uint16_t addr, int read, int addr10) {
+    if (!addr10) {
+        i2c->DR = (addr << 1) | (read ? 1 : 0);
+        I2C_wait_flag(i2c, I2C_SR1_ADDR);
+        (void)i2c->SR1; (void)i2c->SR2;
+    } else {
+        uint8_t header = 0xF0 | ((addr >> 7) & 0x06);
+        i2c->DR = header | 0;
+        I2C_wait_flag(i2c, I2C_SR1_ADD10);
+        I2C_wait_flag(i2c, I2C_SR1_TXE);
+        i2c->DR = addr & 0xFF;
+        I2C_wait_flag(i2c, I2C_SR1_BTF);
+        I2C_start(i2c);
+        i2c->DR = header | (read ? 1 : 0);
+        I2C_wait_flag(i2c, I2C_SR1_ADDR);
+        (void)i2c->SR1; (void)i2c->SR2;
+    }
+}
+
+static inline void I2C_opt_send_data(I2C_TypeDef *i2c, const uint8_t *buf, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        I2C_wait_flag(i2c, I2C_SR1_TXE);
+        i2c->DR = buf[i];
+    }
+    I2C_wait_flag(i2c, I2C_SR1_BTF);
+}
+
+static inline void I2C_opt_recv_data(I2C_TypeDef *i2c, uint8_t *buf, size_t len) {
+    while (len--) {
+        if (len == 0)
+            i2c->CR1 &= ~I2C_CR1_ACK;
+        I2C_wait_flag(i2c, I2C_SR1_RXNE);
+        *buf++ = i2c->DR;
+    }
+    i2c->CR1 |= I2C_CR1_ACK;
+}
+
+static inline int I2C_slave_read(I2C_TypeDef *i2c, uint8_t *buf, size_t max_len) {
+    size_t len = 0;
+    I2C_wait_flag(i2c, I2C_SR1_ADDR);
+    (void)i2c->SR1; (void)i2c->SR2;
+    while (1) {
+        if (i2c->SR1 & I2C_SR1_RXNE) {
+            if (len < max_len)
+                buf[len++] = i2c->DR;
+            else
+                (void)i2c->DR;
+        }
+        if (i2c->SR1 & I2C_SR1_STOPF) {
+            (void)i2c->SR1;
+            i2c->CR1 |= I2C_CR1_PE;
+            break;
+        }
+    }
+    return len;
+}
+
+static inline void I2C_slave_write(I2C_TypeDef *i2c, const uint8_t *buf, size_t len) {
+    I2C_wait_flag(i2c, I2C_SR1_ADDR);
+    (void)i2c->SR1; (void)i2c->SR2;
+    while (len) {
+        I2C_wait_flag(i2c, I2C_SR1_TXE);
+        i2c->DR = *buf++;
+        len--;
+        if (i2c->SR1 & I2C_SR1_AF) {
+            (void)i2c->SR1;
+            i2c->CR1 |= I2C_CR1_PE;
+            return;
+        }
+        if (i2c->SR1 & I2C_SR1_STOPF) {
+            (void)i2c->SR1;
+            i2c->CR1 |= I2C_CR1_PE;
+            return;
+        }
+    }
+    I2C_wait_flag(i2c, I2C_SR1_BTF);
+}
+
+/*----------------------------------------------------------------------------*/
+/* High level helpers                                                          */
+/*----------------------------------------------------------------------------*/
+static inline void I2C_write(I2C_TypeDef *i2c, uint16_t addr, const void *buf, size_t len) {
+    I2C_Config c;
+    I2C_load_config(i2c, &c);
+    I2C_start(i2c);
+    I2C_opt_send_addr(i2c, addr, 0, c.addr10);
+    I2C_opt_send_data(i2c, (const uint8_t *)buf, len);
+    I2C_stop(i2c);
+}
+
+static inline void I2C_read(I2C_TypeDef *i2c, uint16_t addr, void *buf, size_t len) {
+    I2C_Config c;
+    I2C_load_config(i2c, &c);
+    I2C_start(i2c);
+    I2C_opt_send_addr(i2c, addr, 1, c.addr10);
+    I2C_opt_recv_data(i2c, (uint8_t *)buf, len);
+    I2C_stop(i2c);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32_KIT_I2C */

--- a/stm32/include/stm32_kit/lcd.h
+++ b/stm32/include/stm32_kit/lcd.h
@@ -15,31 +15,43 @@
 #include "chrono.h"
 #include "gpio.h"
 #include "pin.h"
+#include "i2c.h"
+#include "config.h"
+#include "lcd_cmd.h"
 
 #ifndef STRING_H_
 # include <string.h>
 #endif
 
 #	include "boards.h"
+#if LCD_USE_I2C
+#if (LCD_I2C_PORT == 1)
+#define LCD_I2C_SCL I2C1_SCL
+#define LCD_I2C_SDA I2C1_SDA
+#elif (LCD_I2C_PORT == 2)
+#define LCD_I2C_SCL I2C2_SCL
+#define LCD_I2C_SDA I2C2_SDA
+#elif (LCD_I2C_PORT == 3)
+#define LCD_I2C_SCL I2C3_SCL
+#define LCD_I2C_SDA I2C3_SDA
+#else
+#error "Unsupported LCD_I2C_PORT"
+#endif
+#endif
+
 
 //#========================================================================
 //#=== Makra pro LCD - ZACATEK
+# define LCD_I2C_EN  (1 << 2)
+# define LCD_I2C_BL  (1 << 3)
+#ifndef LCD_I2C_ADDR
+# define LCD_I2C_ADDR 0x27
+#endif
+#endif
 
-#ifndef CUSTOM_HD44780_COMMANDS
-# define LCD_ON           (0x0C)      // Zapnuti displeje (bez kurzoru)
-# define LCD_OFF          (0x08)      // Vypnuti displeje
-# define LCD_CLR          (0x01)      // Smazani displeje a navrat kurzoru na 1. radek a 1. sloupec
-# define LCD_CUR_ON       (0x0E)      // Zapnuti kurzoru bez blikani (vcetne zapnuti displeje)
-# define LCD_CUR_OFF      LCD_ON      // Vypnuti kurzoru (displej zustane zapnuty)
-# define LCD_CUR_BLINK    (0x0F)      // Zapnuti blikajiciho kurzoru (vcetne zapnuti displeje)
-# define LCD_CUR_NO_BLINK LCD_CUR_ON  // Zapnuti blikajiciho kurzoru (vcetne zapnuti displeje)
-# define LCD_CUR_HOME     (0x03)      // Navrat kurzoru na prvni pozici prvniho radku
-# define LCD_SL           (0x18)      // Rotace displeje vlevo
-# define LCD_SR           (0x1C)      // Rotace displeje vpravo
-# define LCD_LINE1        (0x80)      // Prvni radek prvni pozice	(0x00 + DDRAM = 0x80)
-# define LCD_LINE2        (0xC0)      // Druhy radek prvni pozice	(0x40 + DDRAM = 0xC0)
-# define LCD_LINE3        (0x94)      // Prvni radek prvni pozice (0x14 + DDRAM = 0x94)
-# define LCD_LINE4        (0xD4)      // Prvni radek prvni pozice (0x54 + DDRAM = 0xD4)
+#if LCD_USE_I2C
+static uint8_t lcd_ctrl = LCD_I2C_BL;
+static I2C_TypeDef *lcd_i2c;
 #endif
 
 //#=== Makra pro LCD - KONEC
@@ -60,14 +72,22 @@ INLINE_STM32 void LCD_busy(void) { delay_us(4); } // 400us; Pokud nebude fungova
  * @param  nibble Hodnota v rozmezi 0 - F.
  *
  */
-INLINE_STM32 void LCD_write_nibble(uint8_t nibble) {
+INLINE_STM32 void LCD_write_nibble_i2c(uint8_t nibble) {
+  uint8_t data = ((nibble & 0x0F) << 4) | lcd_ctrl;
+  uint8_t tmp = data | LCD_I2C_EN;
+  I2C_write(lcd_i2c, LCD_I2C_ADDR, &tmp, 1);
+  tmp = data;
+  I2C_write(lcd_i2c, LCD_I2C_ADDR, &tmp, 1);
+}
+
+INLINE_STM32 void LCD_write_nibble_gpio(uint8_t nibble) {
   io_set(LCD_RW, 0);
   io_set(LCD_EN, 0);
   delay_us(1);       // 100us
   io_set(LCD_EN, 1);
 
   nibble &= 0x0F; // Vymaskovani spodnich 4 bitu ze vstupni hodnoty
-  
+
   io_set(LCD_DB4, (nibble & 0x1) >> 0); // Zapis informace
   io_set(LCD_DB5, (nibble & 0x2) >> 1); //  na prislusne
   io_set(LCD_DB6, (nibble & 0x4) >> 2); //  piny (zapis
@@ -78,24 +98,45 @@ INLINE_STM32 void LCD_write_nibble(uint8_t nibble) {
   delay_us(1);
 }
 
+#if LCD_USE_I2C
+# define LCD_write_nibble(n) LCD_write_nibble_i2c(n)
+#else
+# define LCD_write_nibble(n) LCD_write_nibble_gpio(n)
+#endif
+
 /**
  * @brief  Funkce pro rizeni/nastaveni LCD.
  *
  * @param  cmd Kod pro ridici prikaz.
  *
  */
-INLINE_STM32 void LCD_set(uint8_t cmd) {
-  LCD_busy(); // Casova prodleva pro zpracovani ridicich prikazu.
-
-  io_set(LCD_RS, 0);
-  LCD_write_nibble(cmd >> 4); // Poslani 4 hornich bitu na zapis
-  LCD_write_nibble(cmd);      // Poslani 4 dolnich bitu na zapis
-  // delay_us(4);                                              // 400us; V pripade potreby odkomentovat.
+INLINE_STM32 void LCD_set_i2c(uint8_t cmd) {
+  LCD_busy();
+  lcd_ctrl &= ~LCD_I2C_RS;
+  LCD_write_nibble_i2c(cmd >> 4);
+  LCD_write_nibble_i2c(cmd);
 }
 
+INLINE_STM32 void LCD_set_gpio(uint8_t cmd) {
+  LCD_busy();
+  io_set(LCD_RS, 0);
+  LCD_write_nibble_gpio(cmd >> 4);
+  LCD_write_nibble_gpio(cmd);
+}
+
+#if LCD_USE_I2C
+# define LCD_set(cmd) LCD_set_i2c(cmd)
+#else
+# define LCD_set(cmd) LCD_set_gpio(cmd)
+#endif
+
 INLINE_STM32 void LCD_io_setup(enum pin pin) {
+#if !LCD_USE_I2C
   pin_enable(pin);
   pin_setup(pin, PIN_MODE_OUTPUT, PIN_PULL_DEFAULT, PIN_SPEED_HIGH, PIN_TYPE_PUSHPULL);
+#else
+  (void)pin;
+#endif
 }
 
 /**
@@ -103,16 +144,18 @@ INLINE_STM32 void LCD_io_setup(enum pin pin) {
  *
  */
 void LCD_setup(void) {
+#if LCD_USE_I2C
+  lcd_i2c = I2C_setup(I2C_autoselect(LCD_I2C_SCL, LCD_I2C_SDA));
+  delay_ms(50);
+#else
   // 1. Reseni napajeni (skolni kit) - ZACATEK
-#if (STM32_TYPE == 407) // Pro F407 (skolni pripravek)
-  // Nasledujici radky jsou pouze pro skolni pripravek, u domacich neni nutno zapojovat PE10
+#if (STM32_TYPE == 407)
   const enum pin pwr = PE10;
   LCD_io_setup(pwr);
-  io_set(pwr, 0); // DIR = 0; Pouzit prevodnik '245 (z 3.3V na 5V a naopak)
+  io_set(pwr, 0);
 #endif
   // 1. Reseni napajeni (skolni kit) - KONEC
 
-  // 2. Nastaveni pinu a portu - ZACATEK
   __disable_irq();
   LCD_io_setup(LCD_RS);
   LCD_io_setup(LCD_RW);
@@ -122,18 +165,16 @@ void LCD_setup(void) {
   LCD_io_setup(LCD_DB6);
   LCD_io_setup(LCD_DB7);
   __enable_irq();
-  // 2. Nastaveni pinu a portu - KONEC
+#endif
 
-  // 3. Nastaveni/inicializace LCD - ZACATEK
-  LCD_set(0x3); // 1) Reset LCD
-  LCD_set(0x3);
-  LCD_set(0x2);
+  LCD_set(LCD_CMD_FUNCTION(LCD_FUNC_8BIT));
+  LCD_set(LCD_CMD_FUNCTION(LCD_FUNC_8BIT));
+  LCD_set(LCD_CMD_FUNCTION(LCD_FUNC_4BIT));
 
-  LCD_set(0x28); // 2) Nastaveni komunikace, poctu radku a rozliseni: 4bit ; 2 radky ; 5x8 bodu
-  LCD_set(0x0F); // 3) Aktivace displeje: zapnuti displeje a blikajiciho kurzoru
-  LCD_set(0x06); // 4) Chovani displeje pri vypisu znaku: inkrementace adresy a posun kurzoru vpravo po vypsani znaku na LCD
-  LCD_set(0x01); // 5) Smazani displeje
-  // 3. Nastaveni/inicializace LCD - KONEC
+  LCD_set(LCD_CMD_FUNCTION(((LCD_ROWS>1)?LCD_FUNC_2LINE:0) | LCD_FUNC_5x8));
+  LCD_set(LCD_CMD_DISPLAY(LCD_DISP_ON | LCD_CURSOR_ON | LCD_BLINK_ON));
+  LCD_set(LCD_CMD_ENTRY_MODE(LCD_ENTRY_INC));
+  LCD_set(LCD_CMD_CLEAR);
 }
 //#=== Rutiny pro rizeni LCD - KONEC
 //#========================================================================
@@ -147,14 +188,27 @@ void LCD_setup(void) {
  * @param  data Kod pro vypisovany znak, pripadne konkretni znak.
  *
  */
-void LCD_symbol(uint8_t data)
+INLINE_STM32 void LCD_symbol_i2c(uint8_t data)
 {
-  LCD_busy(); // Casova prodleva pro zpracovani ridicich prikazu.
-
-  io_set(LCD_RS, 1);
-  LCD_write_nibble(data >> 4);   // Horni 4bity
-  LCD_write_nibble(data & 0x0F); // Dolni 4bity
+  LCD_busy();
+  lcd_ctrl |= LCD_I2C_RS;
+  LCD_write_nibble_i2c(data >> 4);
+  LCD_write_nibble_i2c(data & 0x0F);
 }
+
+INLINE_STM32 void LCD_symbol_gpio(uint8_t data)
+{
+  LCD_busy();
+  io_set(LCD_RS, 1);
+  LCD_write_nibble_gpio(data >> 4);
+  LCD_write_nibble_gpio(data & 0x0F);
+}
+
+#if LCD_USE_I2C
+# define LCD_symbol(d) LCD_symbol_i2c(d)
+#else
+# define LCD_symbol(d) LCD_symbol_gpio(d)
+#endif
 
 /**
  * @brief  Funkce pro vypis retezce znaku na LCD.
@@ -164,17 +218,43 @@ void LCD_symbol(uint8_t data)
  *
  */
 
-void LCD_print(const char *__restrict__ text) {
-  uint8_t i;
-
-  for (i = 0; i < strlen(text); i++) {
+INLINE_STM32 void LCD_write(const char *__restrict__ text, int len) {
+  for (int i = 0; i < len; i++) {
     LCD_symbol(text[i]);
   }
 }
 
-void LCD_goto(int x, int y) {
+INLINE_STM32 void LCD_print(const char *__restrict__ text) {
+  LCD_write(text, strlen(text));
+}
+
+INLINE_STM32 void LCD_create_char(uint8_t index, const uint8_t bitmap[8]) {
+  LCD_set(LCD_CMD_SET_CGRAM(index * 8));
+  for (int i = 0; i < 8; i++) {
+    LCD_symbol(bitmap[i]);
+  }
+  LCD_set(LCD_CMD_SET_DDRAM(0));
+}
+
+static const uint8_t lcd_battery_char[8] = {
+  0x0E,
+  0x11,
+  0x1F,
+  0x11,
+  0x11,
+  0x1F,
+  0x11,
+  0x0E
+};
+
+INLINE_STM32 void LCD_test_battery(void) {
+  LCD_create_char(0, lcd_battery_char);
+  LCD_symbol(0);
+}
+
+INLINE_STM32 void LCD_goto(int x, int y) {
   const uint8_t row_offset[] = { 0x00, 0x40 };
-  LCD_set(0x80 | (x + row_offset[y - 1]));
+  LCD_set(LCD_CMD_SET_DDRAM(x + row_offset[y - 1]));
 }
 //#=== Rutiny pro praci s LCD - KONEC
 //#========================================================================

--- a/stm32/include/stm32_kit/lcd_cmd.h
+++ b/stm32/include/stm32_kit/lcd_cmd.h
@@ -1,0 +1,57 @@
+#ifndef STM32_KIT_LCD_CMD
+#define STM32_KIT_LCD_CMD
+
+#define LCD_CMD_CLEAR             0x01
+#define LCD_CMD_HOME              0x02
+
+/* Bits for ENTRY_MODE command */
+#define LCD_ENTRY_INC             (1<<1)
+#define LCD_ENTRY_DEC             0
+#define LCD_ENTRY_SHIFT           (1<<0)
+#define LCD_CMD_ENTRY_MODE(f)    (0x04 | ((f) & (LCD_ENTRY_INC|LCD_ENTRY_SHIFT)))
+
+/* Bits for DISPLAY command */
+#define LCD_DISP_ON               (1<<2)
+#define LCD_DISP_OFF              0
+#define LCD_CURSOR_ON             (1<<1)
+#define LCD_CURSOR_OFF            0
+#define LCD_BLINK_ON              (1<<0)
+#define LCD_BLINK_OFF             0
+#define LCD_CMD_DISPLAY(f)       (0x08 | ((f) & (LCD_DISP_ON|LCD_CURSOR_ON|LCD_BLINK_ON)))
+
+/* Bits for SHIFT command */
+#define LCD_SHIFT_DISPLAY         (1<<3)
+#define LCD_SHIFT_CURSOR          0
+#define LCD_SHIFT_RIGHT           (1<<2)
+#define LCD_SHIFT_LEFT            0
+#define LCD_CMD_SHIFT(f)         (0x10 | ((f) & (LCD_SHIFT_DISPLAY|LCD_SHIFT_RIGHT)))
+
+/* Bits for FUNCTION command */
+#define LCD_FUNC_8BIT             (1<<4)
+#define LCD_FUNC_4BIT             0
+#define LCD_FUNC_2LINE            (1<<3)
+#define LCD_FUNC_1LINE            0
+#define LCD_FUNC_5x10             (1<<2)
+#define LCD_FUNC_5x8              0
+#define LCD_CMD_FUNCTION(f)      (0x20 | ((f) & (LCD_FUNC_8BIT|LCD_FUNC_2LINE|LCD_FUNC_5x10)))
+
+#define LCD_CMD_SET_CGRAM(addr)   (0x40 | ((addr) & 0x3F))
+#define LCD_CMD_SET_DDRAM(addr)   (0x80 | ((addr) & 0x7F))
+
+/* Legacy names kept for compatibility */
+#define LCD_ON           LCD_CMD_DISPLAY(LCD_DISP_ON)
+#define LCD_OFF          LCD_CMD_DISPLAY(LCD_DISP_OFF)
+#define LCD_CLR          LCD_CMD_CLEAR
+#define LCD_CUR_ON       LCD_CMD_DISPLAY(LCD_DISP_ON | LCD_CURSOR_ON)
+#define LCD_CUR_OFF      LCD_CMD_DISPLAY(LCD_DISP_ON)
+#define LCD_CUR_BLINK    LCD_CMD_DISPLAY(LCD_DISP_ON | LCD_CURSOR_ON | LCD_BLINK_ON)
+#define LCD_CUR_NO_BLINK LCD_CMD_DISPLAY(LCD_DISP_ON | LCD_CURSOR_ON)
+#define LCD_CUR_HOME     LCD_CMD_HOME
+#define LCD_SL           LCD_CMD_SHIFT(LCD_SHIFT_DISPLAY | LCD_SHIFT_LEFT)
+#define LCD_SR           LCD_CMD_SHIFT(LCD_SHIFT_DISPLAY | LCD_SHIFT_RIGHT)
+#define LCD_LINE1        LCD_CMD_SET_DDRAM(0x00)
+#define LCD_LINE2        LCD_CMD_SET_DDRAM(0x40)
+#define LCD_LINE3        LCD_CMD_SET_DDRAM(0x14)
+#define LCD_LINE4        LCD_CMD_SET_DDRAM(0x54)
+
+#endif /* STM32_KIT_LCD_CMD */


### PR DESCRIPTION
## Summary
- add `I2C_slave_read` and `I2C_slave_write` helpers
- use the new helper in the slave LCD example
- simplify `I2C_load_config` to rely on per-port macros instead of STM32 type checks

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68471807ad1c832397588a9ab798bde1